### PR TITLE
small fix to resolve files on mac

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -379,8 +379,7 @@ tasks {
                     val relativeFile = originalFile.relativeTo(original)
                     val modifiedFile = modified.resolve(relativeFile)
                     val patchFile = File(patches, "$relativeFile.patch")
-
-                    modifiedFile.parentFile.mkdirs()
+                    projectDir.resolve(modifiedFile.parentFile).mkdirs()
                     if (patchFile.exists()) {
                         println("Patching $relativeFile")
                         val patch = UnifiedDiffUtils.parseUnifiedDiff(patchFile.readLines())


### PR DESCRIPTION
I am still getting errors when running `assemble` but I am sure this is because I have Java 14, deprecated classes been nuked. In fact, this entire thing might because of Java 14.

If someone could check if this works on Linux that would be great.